### PR TITLE
Add the ability to use DagsHub Logger programmatically

### DIFF
--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -49,9 +49,9 @@ class DagshubLogger(MlflowLogger):
         token = os.environ["DAGSHUB_USER_TOKEN"]
         if not token:
             token = dagshub.auth.get_token()
-        os.environ["MLFLOW_TRACKING_TOKEN"] = token
-#         os.environ["MLFLOW_TRACKING_USERNAME"] = token
-#         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
+#         os.environ["MLFLOW_TRACKING_TOKEN"] = token
+        os.environ["MLFLOW_TRACKING_USERNAME"] = token
+        os.environ["MLFLOW_TRACKING_PASSWORD"] = token
         
         # Set DagsHub repo_name and repo_owner
         if  not "dagshub" in os.getenv("MLFLOW_TRACKING_URI") and (not self.repo_name or not self.repo_owner):

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -67,7 +67,7 @@ class DagshubLogger(MlflowLogger):
             self.remote = os.getenv("MLFLOW_TRACKING_URI")
 
         self.repo = Repo(
-            owner=self.repo_owner
+            owner=self.repo_owner,
             name=self.repo_name,
             branch=os.getenv("BRANCH", "main"),
         )

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -49,7 +49,6 @@ class DagshubLogger(MlflowLogger):
         token = os.environ["DAGSHUB_USER_TOKEN"]
         if not token:
             token = dagshub.auth.get_token()
-#         os.environ["MLFLOW_TRACKING_TOKEN"] = token
         os.environ["MLFLOW_TRACKING_USERNAME"] = token
         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
         
@@ -58,10 +57,11 @@ class DagshubLogger(MlflowLogger):
             self.repo_name, self.repo_owner = self.splitter(
                 input("Please insert your repository owner_name/repo_name:")
             )
+        # Set DagsHub repo_name and repo_owner using MLflow URI    
         elif not self.repo_name or not self.repo_owner:
             split_mlflow_uri = os.getenv("MLFLOW_TRACKING_URI").split("/")
             self.repo_name, self.repo_owner = split_mlflow_uri[-1].split(".")[0], split_mlflow_uri[-2]
-
+        
         if not self.remote:
             dagshub.init(repo_name=self.repo_name, repo_owner=self.repo_owner)
             self.remote = os.getenv("MLFLOW_TRACKING_URI")

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -53,7 +53,7 @@ class DagshubLogger(MlflowLogger):
         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
         
         # Set DagsHub repo_name and repo_owner
-        if  not "dagshub" in os.getenv("MLFLOW_TRACKING_URI") and (not self.repo_name or not self.repo_owner):
+        if  not "dagshub.com" in os.getenv("MLFLOW_TRACKING_URI") and (not self.repo_name or not self.repo_owner):
             self.repo_name, self.repo_owner = self.splitter(
                 input("Please insert your repository owner_name/repo_name:")
             )

--- a/pycaret/loggers/dagshub_logger.py
+++ b/pycaret/loggers/dagshub_logger.py
@@ -45,24 +45,30 @@ class DagshubLogger(MlflowLogger):
         return splitted[1], splitted[0]
 
     def init_experiment(self, *args, **kargs):
-        # check token exist or not:
-        token = dagshub.auth.get_token()
-        os.environ["MLFLOW_TRACKING_USERNAME"] = token
-        os.environ["MLFLOW_TRACKING_PASSWORD"] = token
-
-        # Check mlflow environment variable is set:
-        if not self.repo_name or not self.repo_owner:
+        # Set DagsHub TOKEN
+        token = os.environ["DAGSHUB_USER_TOKEN"]
+        if not token:
+            token = dagshub.auth.get_token()
+        os.environ["MLFLOW_TRACKING_TOKEN"] = token
+#         os.environ["MLFLOW_TRACKING_USERNAME"] = token
+#         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
+        
+        # Set DagsHub repo_name and repo_owner
+        if  not "dagshub" in os.getenv("MLFLOW_TRACKING_URI") and (not self.repo_name or not self.repo_owner):
             self.repo_name, self.repo_owner = self.splitter(
                 input("Please insert your repository owner_name/repo_name:")
             )
+        elif not self.repo_name or not self.repo_owner:
+            split_mlflow_uri = os.getenv("MLFLOW_TRACKING_URI").split("/")
+            self.repo_name, self.repo_owner = split_mlflow_uri[-1].split(".")[0], split_mlflow_uri[-2]
 
-        if not self.remote or "dagshub" not in os.getenv("MLFLOW_TRACKING_URI"):
+        if not self.remote:
             dagshub.init(repo_name=self.repo_name, repo_owner=self.repo_owner)
             self.remote = os.getenv("MLFLOW_TRACKING_URI")
 
         self.repo = Repo(
-            owner=self.remote.split(os.sep)[-2],
-            name=self.remote.split(os.sep)[-1].replace(".mlflow", ""),
+            owner=self.repo_owner
+            name=self.repo_name,
             branch=os.getenv("BRANCH", "main"),
         )
         self.dvc_folder = self.repo.directory(str(self.paths["dvc_directory"]))


### PR DESCRIPTION
To use DagsHub Logger programmatically, I fetch the user's token from DagsHub's os variable (DAGSHUB_USER_TOKEN) and the remote from MLflow URI (MLFLOW_TRACKING_URI) and use them to initialize dagshub.